### PR TITLE
exist status 0 from successful run

### DIFF
--- a/src/sqrt_stretch.c
+++ b/src/sqrt_stretch.c
@@ -233,5 +233,7 @@ main (int argc, char *argv[])
 
   /* close file, and we are done. */
   GDALClose (out_Dataset);
-
+  
+  /* exit gracefully with a 0 */
+  return 0;
 }


### PR DESCRIPTION
Will made not that the sqrt_stretch tool wasn't returning 0 on success.

This should fix it.  I don't have any easy test to confirm so perhaps @spruceboy can do that.